### PR TITLE
Fix tap interface numbering

### DIFF
--- a/backend/src/gloader/gloader.py
+++ b/backend/src/gloader/gloader.py
@@ -389,7 +389,7 @@ def createVR(myGINI, options):
                     # If so, this router can just tap into it
                     x,rnum = router.name.split("_")
                     x,snum = swname.split("_")
-                    scheck = "Switch_" + snum + rnum
+                    scheck = "Switch_" + rnum + snum
                     brname = findBridgeName(scheck)
                     if (brname == None):
                         swname, brname = createASwitch(router.name, swname, nwIf.network, stopOut)


### PR DESCRIPTION
Use a dictionary to map router-switch pairs to corresponding tap name.
This should allow for larger network topologies