### PR TITLE
Publish gini-toolkit on a tag, and surface releasing in the README

### DIFF
--- a/.github/workflows/gini-toolkit.yml
+++ b/.github/workflows/gini-toolkit.yml
@@ -1,0 +1,53 @@
+# Publishes gini-toolkit (the gBuilder desktop app) to PyPI.
+#
+# One workflow file per project, like the other two: PyPI's trusted publishing binds a single
+# workflow to a project, and a shared file would let a failure in one distribution block the rest.
+#
+# This is the one students install (`pipx install gini-toolkit`), so a tag that publishes gini-core
+# WITHOUT publishing this leaves the app pinned at the old release while its dependency moves
+# underneath it — which is exactly what happened when the hand-run release-pypi.sh went away and
+# nothing replaced it for this package.
+name: publish gini-toolkit
+
+on:
+  push:
+    tags: ["v*"]           # setuptools-scm derives the version from the tag
+  workflow_dispatch:       # and a manual run, for a re-publish after a hiccup
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi      # create this Environment in repo Settings and require a reviewer
+    permissions:
+      id-token: write      # THE line that makes trusted publishing work — no API token anywhere
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # setuptools-scm needs the full history AND the tags, not a shallow clone
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade build
+      - run: python -m build --sdist --wheel --outdir dist/ frontend-ng/
+      # `gini` is a namespace package split with gini-core. Both halves install into the same
+      # directory, so a mistake here is not a build error — it is a working install of a broken
+      # import, discovered by a student. Check the artifact, not the config.
+      - name: the wheel carries the app and NOT the domain model
+        run: |
+          python - <<'PY'
+          import glob, zipfile
+          w = glob.glob("dist/gini_toolkit-*.whl")[0]
+          names = zipfile.ZipFile(w).namelist()
+          assert any(n.startswith("gini/ui/") for n in names), "no gini/ui in the wheel"
+          assert any(n.startswith("gini/services/") for n in names), "no gini/services in the wheel"
+          # gini-core owns this. Two copies on one machine means the resolved one is whichever
+          # landed second, and a proof format that disagrees rejects a student's real work.
+          assert not any(n.startswith("gini/domain/") for n in names), \
+              "shipped gini/domain — that belongs to gini-core and would shadow it"
+          assert "gini/__init__.py" not in names, "shipped __init__.py — that shadows gini-core"
+          entry = [n for n in names if n.endswith("entry_points.txt")]
+          assert entry and b"gbuilder" in zipfile.ZipFile(w).read(entry[0]), \
+              "no gbuilder entry point — the install would leave no command to run"
+          print(w, "ok:", len(names), "files")
+          PY
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -316,6 +316,37 @@ The gRouter has end-to-end forwarding proofs under `backend/grouter-build/tests/
 
 ---
 
+## Releasing
+
+You never type a version number. `setuptools-scm` derives it from the git tag, so **one tag
+versions all three packages at once**:
+
+```bash
+./scripts/release.sh              # show the current version and what each bump would give
+./scripts/release.sh minor        # runs the tests, tags, pushes
+```
+
+Pushing the tag is what publishes: the workflows in `.github/workflows/` fire on `v*` and upload
+`gini-core`, `gini-toolkit` and `gini-teaching-center` to PyPI via trusted publishing, so there is
+no API token anywhere.
+
+Container images are **not** built by a release — they are slow and want a machine of each
+architecture, since these images compile a C router and a RISC-V toolchain:
+
+```bash
+./scripts/images.sh build 6.1.0   # on an arm64 Mac, and again on an amd64 Linux box
+./scripts/images.sh merge 6.1.0   # once, after both — publishes a multi-arch manifest list
+```
+
+One tag then resolves per-architecture at the registry, which is why gBuilder contains no
+architecture logic at all: a client-side guess could be wrong, and wrong means confidently pulling
+binaries that will not run.
+
+Full detail — the release guards and why each exists, GHCR login, the QEMU fallback — is in
+**[`scripts/README.md`](scripts/README.md)**.
+
+---
+
 ## Status
 
 gBuilder 6.0 is under active development. Working today: the visual builder, real packet

--- a/frontend-ng/tests/test_packaging.py
+++ b/frontend-ng/tests/test_packaging.py
@@ -161,3 +161,44 @@ def test_release_and_version_bumps_are_documented_somewhere_findable():
     assert "setuptools-scm" in scripts
     for level in ("patch", "minor", "major"):
         assert f"release.sh {level}" in scripts or level in scripts
+
+
+# -- every distribution must have a way to be published ------------------------ #
+#
+# This is the test that would have caught it: `release-pypi.sh` was the only thing that ever
+# published gini-toolkit, and deleting it left the package with no publisher at all. A tag would
+# have shipped a new gini-core while the app students actually install stayed behind — and nothing
+# would have failed. The release would simply have been half a release.
+
+def _distributions() -> list[str]:
+    return sorted(d.name for d in ROOT.iterdir()
+                  if (d / "pyproject.toml").exists() and d.name != "legacy")
+
+
+def test_every_distribution_has_a_publish_workflow():
+    flows = (ROOT / ".github" / "workflows")
+    published = "\n".join(f.read_text(encoding="utf-8") for f in flows.glob("*.yml"))
+    for d in _distributions():
+        name = (ROOT / d / "pyproject.toml").read_text(encoding="utf-8")
+        dist = next(l.split('"')[1] for l in name.splitlines() if l.startswith("name ="))
+        assert f"outdir dist/ {d}/" in published, (
+            f"{dist} (in {d}/) is built by no workflow — a tag would publish the others and "
+            f"silently leave this one behind")
+
+
+def test_each_project_gets_its_own_workflow_file():
+    """PyPI's trusted publishing binds one workflow file per project, and a shared file would let
+    one distribution's failure block the rest."""
+    flows = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    assert len(flows) >= len(_distributions())
+    for f in flows:
+        built = [l for l in f.read_text(encoding="utf-8").splitlines() if "outdir dist/" in l]
+        assert len(built) == 1, f"{f.name} builds {len(built)} distributions; expected exactly 1"
+
+
+def test_the_release_script_names_every_workflow_it_will_trigger():
+    """The script prints what the tag is about to publish, and you confirm from that list. If it
+    under-reports, you approve a release believing something shipped that did not."""
+    script = (ROOT / "scripts" / "release.sh").read_text(encoding="utf-8")
+    for f in (ROOT / ".github" / "workflows").glob("*.yml"):
+        assert f.name in script, f"release.sh does not mention {f.name} in its confirmation"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -81,6 +81,7 @@ cat <<INFO
 
   This tags $BRANCH and pushes. The tag push is what publishes:
     .github/workflows/gini-core.yml       -> PyPI gini-core $VERSION
+    .github/workflows/gini-toolkit.yml    -> PyPI gini-toolkit $VERSION
     .github/workflows/teaching-center.yml -> PyPI gini-teaching-center $VERSION
 
   Container images are NOT built by this — they are slow and need both machines:


### PR DESCRIPTION
gini-toolkit had no publish workflow. release-pypi.sh was the only thing that ever pushed it to PyPI, and deleting that in the script consolidation left the package with no publisher at all -- a tag would have shipped a new gini-core while the app students actually `pipx install` stayed behind, with nothing failing to say so. Half a release, silently.

Adds .github/workflows/gini-toolkit.yml, mirroring the other two: one workflow file per project (trusted publishing binds one file per project, and a shared file lets one failure block the rest), plus artifact assertions. The wheel must carry gini/ui and gini/services, must NOT carry gini/domain or gini/__init__.py -- both halves of the namespace install into the same directory, so getting this wrong is not a build error but a working install of a broken import -- and must declare the gbuilder entry point, or the install leaves no command to run.

release.sh now names all three workflows in the confirmation it prints. You approve a release from that list, so under-reporting means approving a release believing something shipped that did not.

Three guards in test_packaging.py, the first being the one that would have caught this: every directory with a pyproject.toml must be built by some workflow; each workflow builds exactly one distribution; release.sh mentions every workflow that exists.

README: releasing and image builds were only documented inside a collapsed <details> labelled "Dev tools & building images locally" -- invisible on GitHub until clicked, and not where anyone looks for how to cut a release. Promoted to a top-level "Releasing" section, with scripts/README.md for the detail.